### PR TITLE
feat/coupon: (구매자)다운로드 가능 쿠폰 조회 api 구현 - 정책적 논의 필요

### DIFF
--- a/src/main/java/org/example/eatopia/domain/coupon/controller/CouponController.java
+++ b/src/main/java/org/example/eatopia/domain/coupon/controller/CouponController.java
@@ -70,6 +70,17 @@ public class CouponController {
         return Response.success(responses);
     }
 
+    // TODO: 현재 ADMIN의 생성된 모든 쿠폰 조회와 로직이 동일합니다. 추후 특정 유저가 어떤 쿠폰을 선별 조회 가능할지에 대한 정책적인 논의를 적용하여 로직을 수정해야할 것 같습니다.
+    @PreAuthorize("hasAuthority('ROLE_BUYER')")
+    @GetMapping("/v1/buyer/coupons/downloadable")
+    public Response<Page<CouponResponse>> getDownloadableCoupons(@AuthenticationPrincipal UserPrincipal userAuth,
+                                                                 @PageableDefault(size = 30, sort = "startAt", direction = Sort.Direction.ASC) Pageable pageable) {
+
+        Page<CouponResponse> responses = couponQueryService.getDownloadableCoupons(userAuth, pageable);
+
+        return Response.success(responses);
+    }
+
     @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'ROLE_SELLER')")
     @DeleteMapping("/v1/manager/coupons/{couponId}")
     public Response<Void> deleteCoupon(@AuthenticationPrincipal UserPrincipal userAuth,

--- a/src/main/java/org/example/eatopia/domain/coupon/service/query/CouponQueryService.java
+++ b/src/main/java/org/example/eatopia/domain/coupon/service/query/CouponQueryService.java
@@ -12,4 +12,6 @@ public interface CouponQueryService {
     Page<CouponResponse> getCreatedCoupons(Pageable pageable);
 
     Page<CouponResponse> getCreatedCouponsByMe(UserPrincipal userAuth, Pageable pageable);
+
+    Page<CouponResponse> getDownloadableCoupons(UserPrincipal userAuth, Pageable pageable);
 }

--- a/src/main/java/org/example/eatopia/domain/coupon/service/query/CouponQueryServiceImpl.java
+++ b/src/main/java/org/example/eatopia/domain/coupon/service/query/CouponQueryServiceImpl.java
@@ -80,4 +80,23 @@ public class CouponQueryServiceImpl implements CouponQueryService {
 
         return response;
     }
+
+    public Page<CouponResponse> getDownloadableCoupons(UserPrincipal userAuth, Pageable pageable) {
+
+        Page<Coupon> coupons = couponRepository.findAll(pageable);
+
+        Page<CouponResponse> response = coupons.map(coupon -> {
+            CouponCreatorInfoResponse creator = CouponCreatorInfoResponse.of(
+                    coupon.getUser().getId(),
+                    coupon.getUser().getName(),
+                    coupon.getUser().getCompany(),
+                    coupon.getUser().getUserRole()
+            );
+
+            return CouponResponse.of(coupon, creator);
+        });
+
+        return response;
+
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #91 


## 📝작업 내용
- (구매자)다운로드 가능 쿠폰 조회 api 구현 - 정책적 논의 필요
- TODO에도 써놓긴 했지만
// TODO: 현재 ADMIN의 생성된 모든 쿠폰 조회와 로직이 동일합니다. 추후 특정 유저가 어떤 쿠폰을 선별 조회 가능할지에 대한 정책적인 논의를 적용하여 로직을 수정해야할 것 같습니다.

