### PR TITLE
feat/review: 리뷰 작성 및 신고 동시성 해결

### DIFF
--- a/src/main/java/org/example/eatopia/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/example/eatopia/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,9 @@
 package org.example.eatopia.domain.review.repository;
 
+import jakarta.persistence.LockModeType;
 import org.example.eatopia.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
 
@@ -11,5 +13,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
     Optional<Review> findByIdAndUserId(Long reviewId, Long userId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
 }

--- a/src/main/java/org/example/eatopia/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/org/example/eatopia/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -91,15 +91,16 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     @Override
     public ReviewReportResponse reportReview(Long reviewId, Long userId, ReviewReportRequest request) {
 
+        // 비관적 락 조회
+        Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
+                .orElseThrow(() -> new GlobalException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
         // 중복 신고 불가
         if (reviewReportRepository.existsByReviewIdAndUserId(reviewId, userId)) {
             throw new GlobalException(ReviewErrorCode.REVIEW_ALREADY_REPORTED);
         }
 
-        Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
-                .orElseThrow(() -> new GlobalException(ReviewErrorCode.REVIEW_NOT_FOUND));
         User user = userQueryService.getUserEntityById(userId);
-
         ReviewReport report = ReviewReport.create(review, user, request.reason());
         reviewReportRepository.save(report);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #220 


## 📝작업 내용

### 리뷰 작성 동시성 처리
- 기존 DB 유니크 제약 덕분에 중복 리뷰 삽입 방지
- 중복 삽입 시 발생하는 예외(DataIntegrityViolationException)를 try-catch로 처리하여 충돌 방지
- 테스트 결과: 다수 사용자가 동시에 동일 상품에 리뷰 작성 시 하나만 정상 삽입되고, 나머지는 예외 처리

### 리뷰 신고 동시성 처리
- 기존 DB Unique Constraint로 중복 신고 방지
- 중복 신고 시 발생하는 예외는 기존의 중복 신고 방지 비즈니스 로직을 통해 처리
- review_count 증가 시 비관적 락(PESSIMISTIC_WRITE) 적용으로 동시 신고 시에도 정확한 카운트 유지
- 테스트 결과: 
   - 동일 리뷰에 여러 사용자가 동시에 신고 시 중복 신고 발생하지 않음
   - review_count가 정상적으로 동기화되어 정확히 증가함