### PR TITLE
fix/redis: Hibernate Lazy 직렬화 오류 해결을 위한 Hibernate6Module 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,13 @@ dependencies {
 
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+    // Jackson 직렬화/역직렬화
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6:2.15.2'
+
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 }
 
 // QueryDSL 설정


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #227 

## 📝작업 내용
- Jackson Hibernate6Module 의존성 추가
- ObjectMapper에 Hibernate6Module 등록
- 리뷰 신고 API에서 간헐적으로 발생하던 hibernateLazyInitializer 직렬화 예외 해결
