### PR TITLE
fix/redis: Redis ObjectMapper에 Hibernate6Module 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    // Jackson 직렬화/역직렬화
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6:2.15.2'
 }
 
 // QueryDSL 설정

--- a/src/main/java/org/example/eatopia/common/infra/config/RedisCacheConfig.java
+++ b/src/main/java/org/example/eatopia/common/infra/config/RedisCacheConfig.java
@@ -3,6 +3,7 @@ package org.example.eatopia.common.infra.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.example.eatopia.domain.product.dto.response.ProductListResponse;
 import org.example.eatopia.domain.product.dto.response.ProductResponse;
@@ -38,6 +39,7 @@ public class RedisCacheConfig {
         // Redis 전용 ObjectMapper 생성 및 설정
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new Hibernate6Module());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         // 다형성 지원을 위한 기본 타이핑 활성화 (보안을 위해 LaissezFaireSubTypeValidator 대신 사용)


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #227 


## 📝작업 내용
- Jackson Hibernate6Module 의존성 추가
- ObjectMapper에 Hibernate6Module 등록
- 리뷰 신고 API에서 간헐적으로 발생하던 hibernateLazyInitializer 직렬화 예외 해결